### PR TITLE
Unified python api

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,11 +120,11 @@ set(CARAMEL_SOURCES
 add_library(caramel_lib STATIC ${CARAMEL_SOURCES})
 target_link_libraries(caramel_lib PUBLIC OpenMP::OpenMP_CXX cereal::cereal)
 
-pybind11_add_module(caramel ${PROJECT_SOURCE_DIR}/python_bindings/PythonBindings.cc)
-target_link_libraries(caramel PUBLIC caramel_lib)
+pybind11_add_module(_caramel ${PROJECT_SOURCE_DIR}/python_bindings/PythonBindings.cc)
+target_link_libraries(_caramel PUBLIC caramel_lib)
 
 target_compile_options(caramel_lib PRIVATE ${CARAMEL_COMPILE_OPTIONS})
-target_compile_options(caramel PRIVATE ${CARAMEL_COMPILE_OPTIONS})
+target_compile_options(_caramel PRIVATE ${CARAMEL_COMPILE_OPTIONS})
 
 message("===================================================")
 message("\tProject Directory = ${PROJECT_SOURCE_DIR}")

--- a/python_bindings/PythonBindings.cc
+++ b/python_bindings/PythonBindings.cc
@@ -24,7 +24,7 @@ template <typename T> void bindCsf(py::module &module, const char *name, const u
       .def_static("load", &Csf<T>::load, py::arg("filename"), py::arg("type_id") = type_id);
 }
 
-PYBIND11_MODULE(caramel, module) { // NOLINT
+PYBIND11_MODULE(_caramel, module) { // NOLINT
   bindCsf<uint32_t>(module, "CSFUint32", 1);
   bindCsf<std::array<char, 10>>(module, "CSFChar10", 2);
   bindCsf<std::array<char, 12>>(module, "CSFChar12", 3);

--- a/python_bindings/PythonBindings.cc
+++ b/python_bindings/PythonBindings.cc
@@ -20,8 +20,13 @@ template <typename T> void bindCsf(py::module &module, const char *name, const u
            }),
            py::arg("keys"), py::arg("values"), py::arg("verbose") = true)
       .def("query", &Csf<T>::query, py::arg("key"))
-      .def("save", &Csf<T>::save, py::arg("filename"), py::arg("type_id") = type_id)
-      .def_static("load", &Csf<T>::load, py::arg("filename"), py::arg("type_id") = type_id);
+      // Call save / load through a lambda to avoid user visibility of type_id.
+      .def("save", [type_id](Csf<T> &self, const std::string &filename) {
+          return self.save(filename, type_id);
+       }, py::arg("filename"))
+      .def_static("load", [type_id](const std::string &filename) {
+          return Csf<T>::load(filename, type_id);
+        }, py::arg("filename"));
 }
 
 PYBIND11_MODULE(_caramel, module) { // NOLINT

--- a/python_bindings/PythonBindings.cc
+++ b/python_bindings/PythonBindings.cc
@@ -12,7 +12,7 @@ namespace py = pybind11;
 
 namespace caramel::python {
 
-template <typename T> void bindCsf(py::module &module, const char *name) {
+template <typename T> void bindCsf(py::module &module, const char *name, const uint32_t type_id) {
   py::class_<Csf<T>, std::shared_ptr<Csf<T>>>(module, name)
       .def(py::init([](const std::vector<std::string> &keys,
                        const std::vector<T> &values, bool verbose) {
@@ -20,15 +20,16 @@ template <typename T> void bindCsf(py::module &module, const char *name) {
            }),
            py::arg("keys"), py::arg("values"), py::arg("verbose") = true)
       .def("query", &Csf<T>::query, py::arg("key"))
-      .def("save", &Csf<T>::save, py::arg("filename"))
-      .def_static("load", &Csf<T>::load, py::arg("filename"));
+      .def("save", &Csf<T>::save, py::arg("filename"), py::arg("type_id") = type_id)
+      .def_static("load", &Csf<T>::load, py::arg("filename"), py::arg("type_id") = type_id);
 }
 
 PYBIND11_MODULE(caramel, module) { // NOLINT
-  bindCsf<uint32_t>(module, "CSF");
-  bindCsf<std::array<char, 10>>(module, "CSFChar10");
-  bindCsf<std::array<char, 12>>(module, "CSFChar12");
-  bindCsf<std::string>(module, "CSFString");
+  bindCsf<uint32_t>(module, "CSFUint32", 1);
+  bindCsf<std::array<char, 10>>(module, "CSFChar10", 2);
+  bindCsf<std::array<char, 12>>(module, "CSFChar12", 3);
+  bindCsf<std::string>(module, "CSFString", 4);
+  py::register_exception<CsfDeserializationException>(module, "CsfDeserializationException");
 }
 
 } // namespace caramel::python

--- a/python_bindings/caramel/__init__.py
+++ b/python_bindings/caramel/__init__.py
@@ -1,0 +1,75 @@
+from ._caramel import *
+
+
+def CSF(keys, values, max_to_validate=None):
+    """
+    Constructs a CSF, automatically inferring the correct CSF backend.
+
+    Arguments:
+        keys: List of hashable keys.
+        values: List of values to use in the CSF.
+        max_to_validate: If provided, only the first "max_to_validate" values
+            will be checked when inferring the correct CSF backend.
+    
+    Returns:
+        A CSF containing the desired key-value mapping.
+
+    Raises:
+        ValueError if the keys and values cannot be used to construct a CSF.
+    """
+    if not len(keys):
+        raise ValueError("Keys must be non-empty but found length 0.")
+    if not len(values):
+        raise ValueError("Values must be non-empty but found length 0.")
+    if len(keys) != len(values):
+        raise ValueError("Keys and values must have the same length.")
+    if not isinstance(keys[0], (str, bytes)):
+        raise ValueError(f"Keys must be str or bytes, found {type(keys[0])}")
+
+    if isinstance(values[0], int):
+        return CSFUint32(keys, values)
+
+    if isinstance(values[0], (str, bytes)):
+        # call out to one of the dedicated-length strings
+        max_idx = max_to_validate
+        validate_values = values[:max_idx] if max_idx else values
+        value_length = _infer_length(values)
+        if value_length == 10:
+            return CSFChar10(keys, values)
+        elif value_length == 12:
+            return CSFChar12(keys, values)
+        else:
+            return CSFString(keys, values)
+    raise ValueError(f"Unsupported value type: {type(values[0])}")
+
+
+
+def _infer_length(values):
+    target_length = len(values[0])
+    for v in values:
+        if len(v) != target_length:
+            return None
+    return target_length
+
+
+def load(filename):
+    """
+    Loads a CSF from file.
+
+    Arguments:
+        filename: File containing a serialized CSF.
+    
+    Returns:
+        A CSF of the correct sub-type.
+
+    Raises:
+        ValueError if the filename does not contain a valid CSF.
+    """
+    csf_classes = [CSFUint32, CSFChar10, CSFChar12, CSFString]
+    for csf_class in csf_classes:
+        try:
+            csf = csf_class.load(filename)
+            return csf
+        except CsfDeserializationException as e:
+            continue
+    raise ValueError(f"File {filename} does not contain a deserializable CSF.")

--- a/python_tests/test_csf.py
+++ b/python_tests/test_csf.py
@@ -28,7 +28,7 @@ def test_csf_int():
 
 
 @pytest.mark.unit
-def test_csf_byte_strings():
+def test_csf_byte_string_keys():
     keys = [f"key{i}".encode("utf-8") for i in range(1000)]
     values = [i for i in range(1000)]
     run_csf_int_test(keys, values)
@@ -37,7 +37,7 @@ def test_csf_byte_strings():
 @pytest.mark.unit
 def test_csf_char_10():
     keys = [f"key{i}".encode("utf-8") for i in range(1000)]
-    values = [list(f"value{i}".ljust(10)[:10]) for i in range(1000)]
+    values = [str(f"value{i}".ljust(10)[:10]) for i in range(1000)]
 
     csf = caramel.CSFChar10(keys, values)
 
@@ -84,4 +84,52 @@ def test_csf_load_incorrect_type_fails():
         csf.save(filename)
         csf = caramel.CSFUint32.load(filename)
     os.remove(filename)
+
+
+@pytest.mark.unit
+def test_auto_infer_char10():
+    keys = [f"key{i}".encode("utf-8") for i in range(1000)]
+    values = [str(f"value{i}".ljust(10)[:10]) for i in range(1000)]
+    csf = caramel.CSF(keys, values)
+    assert isinstance(csf, caramel.CSFChar10)
+    filename = "temp.csf"
+    csf.save(filename)
+    csf = caramel.load(filename)
+    assert isinstance(csf, caramel.CSFChar10)
+    os.remove(filename)
     
+
+def test_auto_infer_char12():
+    keys = [f"key{i}".encode("utf-8") for i in range(1000)]
+    values = [str(f"value{i}".ljust(12)[:12]) for i in range(1000)]
+    csf = caramel.CSF(keys, values)
+    assert isinstance(csf, caramel.CSFChar12)
+    filename = "temp.csf"
+    csf.save(filename)
+    csf = caramel.load(filename)
+    assert isinstance(csf, caramel.CSFChar12)
+    os.remove(filename)
+
+
+def test_auto_infer_string():
+    keys = [f"key{i}".encode("utf-8") for i in range(1000)]
+    values = [f"value{i}" for i in range(1000)]
+    csf = caramel.CSF(keys, values)
+    assert isinstance(csf, caramel.CSFString)
+    filename = "temp.csf"
+    csf.save(filename)
+    csf = caramel.load(filename)
+    assert isinstance(csf, caramel.CSFString)
+    os.remove(filename)
+
+
+def test_auto_infer_int():
+    keys = [f"key{i}".encode("utf-8") for i in range(1000)]
+    values = [i for i in range(1000)]
+    csf = caramel.CSF(keys, values)
+    assert isinstance(csf, caramel.CSFUint32)
+    filename = "temp.csf"
+    csf.save(filename)
+    csf = caramel.load(filename)
+    assert isinstance(csf, caramel.CSFUint32)
+    os.remove(filename)

--- a/python_tests/test_csf.py
+++ b/python_tests/test_csf.py
@@ -4,77 +4,75 @@ import caramel
 import pytest
 
 
-def run_csf_int_test(keys, values):
-    csf = caramel.CSFUint32(keys, values)
+gen_str_keys = lambda n: [f"key{i}" for i in range(n)]
+gen_byte_keys = lambda n: [f"key{i}".encode("utf-8") for i in range(n)]
+gen_int_values = lambda n: [i for i in range(n)]
+gen_charX_values = lambda n, x: [str(f"v{i}".ljust(x)[:x]) for i in range(n)]
+gen_str_values = lambda n: [f"value{i}" for i in range(n)]
 
+
+def assert_all_correct(keys, values, csf):
     for key, value in zip(keys, values):
         assert csf.query(key) == value
 
+def assert_build_save_load_correct(keys, values, CSFClass, wrap_fn=None):
+    csf = CSFClass(keys, values)
+    if wrap_fn:
+        csf = wrap_fn(csf)
+    assert_all_correct(keys, values, csf)
     filename = "temp.csf"
     csf.save(filename)
-    csf = caramel.CSFUint32.load(filename)
+    csf = CSFClass.load(filename)
+    if wrap_fn:
+        csf = wrap_fn(csf)
+    assert_all_correct(keys, values, csf)
+    os.remove(filename)
 
-    for key, value in zip(keys, values):
-        assert csf.query(key) == value
-
+def assert_simple_api_correct(keys, values):
+    csf = caramel.CSF(keys, values)
+    assert_all_correct(keys, values, csf)
+    filename = "temp.csf"
+    csf.save(filename)
+    csf = caramel.load(filename)
+    assert_all_correct(keys, values, csf)
     os.remove(filename)
 
 
 @pytest.mark.unit
 def test_csf_int():
-    keys = [f"key{i}" for i in range(1000)]
-    values = [i for i in range(1000)]
-    run_csf_int_test(keys, values)
+    keys = gen_str_keys(1000)
+    values = gen_int_values(1000)
+    assert_build_save_load_correct(keys, values, caramel.CSFUint32)
 
 
 @pytest.mark.unit
-def test_csf_byte_string_keys():
-    keys = [f"key{i}".encode("utf-8") for i in range(1000)]
-    values = [i for i in range(1000)]
-    run_csf_int_test(keys, values)
+def test_byte_keys():
+    keys = gen_byte_keys(1000)
+    values = gen_int_values(1000)
+    assert_build_save_load_correct(keys, values, caramel.CSFUint32)
 
 
 @pytest.mark.unit
 def test_csf_char_10():
-    keys = [f"key{i}".encode("utf-8") for i in range(1000)]
-    values = [str(f"value{i}".ljust(10)[:10]) for i in range(1000)]
+    keys = gen_byte_keys(1000)
+    values = gen_charX_values(1000, 10)
+    wrap_fn = lambda csf: caramel.CSFQueryWrapper(csf, lambda x: ''.join(x))
+    assert_build_save_load_correct(keys, values, caramel.CSFChar10, wrap_fn)
 
-    list_to_str = lambda x: ''.join(x)
-    csf = caramel.CSFQueryWrapper(caramel.CSFChar10(keys, values), list_to_str)
 
-    for key, value in zip(keys, values):
-        print(csf.query, csf.query(key))
-        assert csf.query(key) == value
-
-    filename = "temp.csf"
-    csf.save(filename)
-    csf = caramel.CSFQueryWrapper(caramel.CSFChar10.load(filename), list_to_str)
-
-    for key, value in zip(keys, values):
-        print(csf.query, csf.query(key))
-        assert csf.query(key) == value
-
-    os.remove(filename)
+@pytest.mark.unit
+def test_csf_char_12():
+    keys = gen_byte_keys(1000)
+    values = gen_charX_values(1000, 12)
+    wrap_fn = lambda csf: caramel.CSFQueryWrapper(csf, lambda x: ''.join(x))
+    assert_build_save_load_correct(keys, values, caramel.CSFChar12, wrap_fn)
 
 
 @pytest.mark.unit
 def test_csf_string():
-    keys = [f"key{i}".encode("utf-8") for i in range(1000)]
-    values = [f"value{i}" for i in range(1000)]
-
-    csf = caramel.CSFString(keys, values)
-
-    for key, value in zip(keys, values):
-        assert csf.query(key) == value
-
-    filename = "temp.csf"
-    csf.save(filename)
-    csf = caramel.CSFString.load(filename)
-
-    for key, value in zip(keys, values):
-        assert csf.query(key) == value
-
-    os.remove(filename)
+    keys = gen_byte_keys(1000)
+    values = gen_str_values(1000)
+    assert_build_save_load_correct(keys, values, caramel.CSFString)
 
 
 @pytest.mark.unit
@@ -91,48 +89,44 @@ def test_csf_load_incorrect_type_fails():
 
 @pytest.mark.unit
 def test_auto_infer_char10():
-    keys = [f"key{i}".encode("utf-8") for i in range(1000)]
-    values = [str(f"value{i}".ljust(10)[:10]) for i in range(1000)]
-    csf = caramel.CSF(keys, values)
-    assert isinstance(csf, caramel.CSFQueryWrapper)
-    filename = "temp.csf"
-    csf.save(filename)
-    csf = caramel.load(filename)
-    assert isinstance(csf, caramel.CSFQueryWrapper)
-    os.remove(filename)
+    keys = gen_byte_keys(1000)
+    values = gen_charX_values(1000, 10)
+    assert caramel._infer_backend(keys, values) == caramel.CSFChar10
 
 
 def test_auto_infer_char12():
-    keys = [f"key{i}".encode("utf-8") for i in range(1000)]
-    values = [str(f"value{i}".ljust(12)[:12]) for i in range(1000)]
-    csf = caramel.CSF(keys, values)
-    assert isinstance(csf, caramel.CSFQueryWrapper)
-    filename = "temp.csf"
-    csf.save(filename)
-    csf = caramel.load(filename)
-    assert isinstance(csf, caramel.CSFQueryWrapper)
-    os.remove(filename)
+    keys = gen_byte_keys(1000)
+    values = gen_charX_values(1000, 12)
+    assert caramel._infer_backend(keys, values) == caramel.CSFChar12
 
 
 def test_auto_infer_string():
-    keys = [f"key{i}".encode("utf-8") for i in range(1000)]
-    values = [f"value{i}" for i in range(1000)]
-    csf = caramel.CSF(keys, values)
-    assert isinstance(csf, caramel.CSFString)
-    filename = "temp.csf"
-    csf.save(filename)
-    csf = caramel.load(filename)
-    assert isinstance(csf, caramel.CSFString)
-    os.remove(filename)
+    keys = gen_str_keys(1000)
+    values = gen_str_values(1000)
+    assert caramel._infer_backend(keys, values) == caramel.CSFString
+
+
+def test_auto_infer_bytes():
+    keys = gen_str_keys(1000)
+    values = [f"V{i}".encode("utf-8") for i in range(1000)]
+    assert caramel._infer_backend(keys, values) == caramel.CSFString
 
 
 def test_auto_infer_int():
-    keys = [f"key{i}".encode("utf-8") for i in range(1000)]
-    values = [i for i in range(1000)]
-    csf = caramel.CSF(keys, values)
-    assert isinstance(csf, caramel.CSFUint32)
-    filename = "temp.csf"
-    csf.save(filename)
-    csf = caramel.load(filename)
-    assert isinstance(csf, caramel.CSFUint32)
-    os.remove(filename)
+    keys = gen_str_keys(1000)
+    values = gen_int_values(1000)
+    assert caramel._infer_backend(keys, values) == caramel.CSFUint32
+
+
+def test_end_to_end():
+    # Tests the full backend-inference + wrapper.
+    num_elements = 100
+    keys = gen_str_keys(num_elements)
+    value_sets = [
+        gen_int_values(num_elements),
+        gen_str_values(num_elements),
+        gen_charX_values(num_elements, 10),
+        gen_charX_values(num_elements, 12),
+    ]
+    for values in value_sets:
+        assert_simple_api_correct(keys, values)

--- a/python_tests/test_csf.py
+++ b/python_tests/test_csf.py
@@ -39,16 +39,19 @@ def test_csf_char_10():
     keys = [f"key{i}".encode("utf-8") for i in range(1000)]
     values = [str(f"value{i}".ljust(10)[:10]) for i in range(1000)]
 
-    csf = caramel.CSFChar10(keys, values)
+    list_to_str = lambda x: ''.join(x)
+    csf = caramel.CSFQueryWrapper(caramel.CSFChar10(keys, values), list_to_str)
 
     for key, value in zip(keys, values):
+        print(csf.query, csf.query(key))
         assert csf.query(key) == value
 
     filename = "temp.csf"
     csf.save(filename)
-    csf = caramel.CSFChar10.load(filename)
+    csf = caramel.CSFQueryWrapper(caramel.CSFChar10.load(filename), list_to_str)
 
     for key, value in zip(keys, values):
+        print(csf.query, csf.query(key))
         assert csf.query(key) == value
 
     os.remove(filename)
@@ -91,23 +94,23 @@ def test_auto_infer_char10():
     keys = [f"key{i}".encode("utf-8") for i in range(1000)]
     values = [str(f"value{i}".ljust(10)[:10]) for i in range(1000)]
     csf = caramel.CSF(keys, values)
-    assert isinstance(csf, caramel.CSFChar10)
+    assert isinstance(csf, caramel.CSFQueryWrapper)
     filename = "temp.csf"
     csf.save(filename)
     csf = caramel.load(filename)
-    assert isinstance(csf, caramel.CSFChar10)
+    assert isinstance(csf, caramel.CSFQueryWrapper)
     os.remove(filename)
-    
+
 
 def test_auto_infer_char12():
     keys = [f"key{i}".encode("utf-8") for i in range(1000)]
     values = [str(f"value{i}".ljust(12)[:12]) for i in range(1000)]
     csf = caramel.CSF(keys, values)
-    assert isinstance(csf, caramel.CSFChar12)
+    assert isinstance(csf, caramel.CSFQueryWrapper)
     filename = "temp.csf"
     csf.save(filename)
     csf = caramel.load(filename)
-    assert isinstance(csf, caramel.CSFChar12)
+    assert isinstance(csf, caramel.CSFQueryWrapper)
     os.remove(filename)
 
 

--- a/python_tests/test_csf.py
+++ b/python_tests/test_csf.py
@@ -4,15 +4,15 @@ import caramel
 import pytest
 
 
-def run_csf_test(keys, values):
-    csf = caramel.CSF(keys, values)
+def run_csf_int_test(keys, values):
+    csf = caramel.CSFUint32(keys, values)
 
     for key, value in zip(keys, values):
         assert csf.query(key) == value
 
     filename = "temp.csf"
     csf.save(filename)
-    csf = caramel.CSF.load(filename)
+    csf = caramel.CSFUint32.load(filename)
 
     for key, value in zip(keys, values):
         assert csf.query(key) == value
@@ -21,17 +21,17 @@ def run_csf_test(keys, values):
 
 
 @pytest.mark.unit
-def test_csf():
+def test_csf_int():
     keys = [f"key{i}" for i in range(1000)]
     values = [i for i in range(1000)]
-    run_csf_test(keys, values)
+    run_csf_int_test(keys, values)
 
 
 @pytest.mark.unit
 def test_csf_byte_strings():
     keys = [f"key{i}".encode("utf-8") for i in range(1000)]
     values = [i for i in range(1000)]
-    run_csf_test(keys, values)
+    run_csf_int_test(keys, values)
 
 
 @pytest.mark.unit
@@ -72,3 +72,16 @@ def test_csf_string():
         assert csf.query(key) == value
 
     os.remove(filename)
+
+
+@pytest.mark.unit
+def test_csf_load_incorrect_type_fails():
+    filename = "temp.csf"
+    with pytest.raises(caramel.CsfDeserializationException) as e:
+        keys = [f"key{i}".encode("utf-8") for i in range(1000)]
+        values = [f"value{i}" for i in range(1000)]
+        csf = caramel.CSFString(keys, values)
+        csf.save(filename)
+        csf = caramel.CSFUint32.load(filename)
+    os.remove(filename)
+    

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ class CMakeBuild(build_ext):
             f"-DPYTHON_EXECUTABLE={sys.executable}",
             f"-DCMAKE_BUILD_TYPE={cfg}",  # not used on MSVC, but no harm
         ]
-        build_args = ["-t", "caramel"]
+        build_args = ["-t", "_caramel"]
         # Adding CMake arguments set as environment variable
         # (needed e.g. to build for ARM OSx on conda-forge)
         if "CMAKE_ARGS" in os.environ:
@@ -106,17 +106,17 @@ class CMakeBuild(build_ext):
         subprocess.check_call(["cmake", ext.sourcedir] + cmake_args, cwd=build_dir)
         subprocess.check_call(["cmake", "--build", "."] + build_args, cwd=build_dir)
 
-
 setup(
     name="caramel",
     version="0.0.1",
-    packages=find_packages(),
+    packages=find_packages(where="./python_bindings/"),
+    package_dir={"":"python_bindings"},
     author="Ben Coleman, Vihan Lakshman, David Torres, Chen Luo",
     author_email="detorresramos1@gmail.com",
     description="A Succinct Read-Only Lookup Table via Compressed Static Functions",
     long_description="",
     license_files=("LICENSE",),
-    ext_modules=[CMakeExtension("caramel")],
+    ext_modules=[CMakeExtension("caramel._caramel")],
     cmdclass={"build_ext": CMakeBuild},
     zip_safe=False,
     extras_require={"test": ["pytest>=6.0"]},


### PR DESCRIPTION
Unify the various CSF backends into a single Python API call.


### Design
There are a few designs that could expose the same interface, but I ended up doing it like this:
1. Add a `type_id` argument to the save / load functions in CSF, so that we can throw errors when attempting to deserialize a CSF of the incorrect type. To avoid messing with the C++ API, this is added with a default value of 0 (if unspecified, library behaves exactly as before).
2. In the Python bindings, bind each CSF using a unique `type_id` in the `save` and `load` methods.
3. Wrap the C++ `caramel` library into a (private) `_caramel` module that is imported by a (public) Python `caramel` module.
4. Auto-infer (in Python) the correct backend to use for a given key-value set.5. 

### Usage
Before:
```python
import caramel
# Construction
keys = ["1", "2", "3"]
values = ["value_1", "value_2", "value_3"]
csf = caramel.CSFString(keys, values)
# Serialization / deserialization
csf.save("mapping.csf")
csf = caramel.CSFString.load("mapping.csf")
```

Now:
```python
import caramel
# Construction
keys = ["1", "2", "3"]
values = ["value_1", "value_2", "value_3"]
csf = caramel.CSF(keys, values)  # Auto-inferred as a CSFString
# Serialization / deserialization
csf.save("mapping.csf")
csf = caramel.load("mapping.csf")  # Auto-inferred to load as CSFString
```

Note that the "before" code is still valid and produces the expected results, so this is non-breaking.

### Alternative Designs
I considered other options, like having all the CSFs inherit from a base class and then using Cereal to serialize the polymorphic children (`CSFUint32`, `CSFString`, etc) using RTTI. But this doesn't work because if we wrap all the `CSF<T>` children in a non-template parent `BaseCSF`, we would be unable to define virtual members for `make<T>`, `query<T>`, etc (and so be unable to call any methods on the deserialized CSF without downcasting, as we would only have a `BaseCSF` pointer).

Another option is to use `typeid` to get the `std::type_info` about the template type. This would simplify the (API developer no longer has to specify a serialization `type_id`) but this has some major issues. First, it's non-portable and unstable - `std::type_info` is not guaranteed to be the same even across different compilations (and in fact, a complaint compiler can just set `std::type_info` to the same string for all types). Second, it doesn't extend well - if we ever decide to template on the key type or something else, we would have to somehow hash the two `std::type_info` values together (risking collisions).
